### PR TITLE
Allow outbound traffic on Discourse

### DIFF
--- a/discourse.tf
+++ b/discourse.tf
@@ -9,7 +9,8 @@ resource "aws_instance" "discourse" {
     monitoring = true
     vpc_security_group_ids = [
       "${aws_security_group.web-prod.id}",
-      "${aws_security_group.ssh-gbre.id}"
+      "${aws_security_group.ssh-gbre.id}",
+      "${aws_security_group.outbound-all.id}"
     ]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -184,6 +184,24 @@ resource "aws_security_group" "ssh-gbre" {
     }
 }
 
+resource "aws_security_group" "outbound-all" {
+    name = "outbound_all"
+    description = "Allow all outbound traffic"
+
+    egress
+    {
+        from_port = 0
+        to_port = 65535
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    tags
+    {
+        Name = "outbound_all"
+    }
+}
+
 resource "aws_security_group" "ssh-vpc" {
     name = "ssh_vpc"
     description = "Allow SSH traffic from our VPC"


### PR DESCRIPTION
Fix my accidental implict restriction on outbound traffic for Discourse.
Blame default terraform behavior differing from AWS's console